### PR TITLE
Add project manifest and Claude configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Setup
+
+```bash
+# Environment setup
+conda env create -f 0.visualize-orf-data/environment.yml
+conda activate visualize-orf
+
+# Initialize submodules
+git submodule update --init --recursive
+
+# Configure commit template for co-author attribution
+git config --local commit.template .gitmessage
+```
+
+## Key Commands
+
+```bash
+# Run Jupyter notebooks for analysis
+cd 0.visualize-orf-data && jupyter lab
+```
+
+## Architecture
+
+**Main analysis directory:** `0.visualize-orf-data/`
+- `utils.py` - Data loading utilities for S3/local access
+- Analysis notebooks: metadata creation, UMAP plotting, negative control analysis
+- Cell painting dataset with 13 experimental batches
+
+**Git workflow:** Use `git commit` (without `-m`) for co-author attribution via template
+
+## Ignore Patterns
+
+- Completely ignore the folders `datasets/` and `jump-orf-data/` - these are submodules that should not be worried about

--- a/manifests/profile_index.csv
+++ b/manifests/profile_index.csv
@@ -1,0 +1,3 @@
+"subset","url","etag"
+"compound_no_source7","https://cellpainting-gallery.s3.amazonaws.com/cpg0042-chandrasekaran-jump/source_all/workspace/profiles/jump-profiling-recipe_2024_598189f/compound_no_source7/profiles_var_mad_int_featselect_harmony/profiles_var_mad_int_featselect_harmony.parquet","35cb79ad41b1a4eb9afeab0d90035dfa-330"
+"compound_no_source7_interpretable","https://cellpainting-gallery.s3.amazonaws.com/cpg0042-chandrasekaran-jump/source_all/workspace/profiles/jump-profiling-recipe_2024_598189f/compound_no_source7/profiles_var_mad_int_featselect_harmony/profiles_var_mad_int_featselect.parquet","3ece1cc202c4a2190e84a95a2dd2d6b3-418"


### PR DESCRIPTION
## Summary
- Add CLAUDE.md with repository setup instructions, architecture documentation, and workflow guidance
- Add manifests/profile_index.csv with compound profile URLs and ETags for public data access
- Profiles processed using jump-profiling-recipe (broadinstitute/598189f) following JUMP dataset conventions

## Files Added
- `CLAUDE.md`: Repository configuration for Claude Code with setup, commands, and architecture details
- `manifests/profile_index.csv`: Project manifest with two profile versions:
  - `compound_no_source7`: Final harmony-processed profiles (2.6GB)
  - `compound_no_source7_interpretable`: Interpretable profiles without harmony (3.3GB)

## Data Access
Both profiles are publicly accessible via S3 with proper ETags for data integrity verification. URLs follow the standard JUMP dataset convention for full reproducibility.

🤖 Generated with [Claude Code](https://claude.ai/code)